### PR TITLE
Handle missing and duplicate citation keys in bibliographies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: namedropR
 Type: Package
 Title: Create Visual Citations for Presentation Slides
-Version: 2.3.3.9000
+Version: 2.3.3.9001
 Authors@R: c(
     person(given = c("Christian", "A."),
            family = "Gebhard",

--- a/R/drop_name_crossref.R
+++ b/R/drop_name_crossref.R
@@ -54,10 +54,6 @@ drop_name_crossref <- function(dois, ...) {
     df$BIBTEXKEY[stringr::str_length(names(dois))>0] <- names(dois)[stringr::str_length(names(dois))>0]
   }
 
-  #Ensure BIBTEXKEY are unique
-  letters_blank <- c("", letters)
-  df <- dplyr::ungroup(dplyr::mutate(dplyr::group_by(df, .data$BIBTEXKEY), `BIBTEXKEY` = stringr::str_replace_all(paste0(.data$BIBTEXKEY, letters_blank[1:dplyr::n()]), " ", "_")))
-
   drop_name(df, ...)
 
 }

--- a/inst/testdata/missing_duplicated.bib
+++ b/inst/testdata/missing_duplicated.bib
@@ -1,0 +1,59 @@
+@misc{short_author,
+  date = {1974-01-02},
+  month = mar,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {248},
+  number = {5443},
+  pages = {30--31},
+  author = {DEF},
+  title = {first original entry},
+  journaltitle = {Nature}
+}
+
+@misc{short_author,
+  date = {1974-01-02},
+  month = mar,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {248},
+  number = {5443},
+  pages = {30--31},
+  author = {DEF},
+  title = {duplicated citation key},
+  journaltitle = {Nature}
+}
+
+@misc{,
+  date = {1974-01-02},
+  month = mar,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {248},
+  number = {5443},
+  pages = {30--31},
+  author = {DEF},
+  title = {no key supplied 1},
+  journaltitle = {Absurdly long Journal Title for the most fancy scientific field.}
+}
+
+@misc{,
+  date = {1974-01-02},
+  month = mar,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {248},
+  number = {5443},
+  pages = {30--31},
+  author = {DEF},
+  title = {no key supplied 2},
+  journaltitle = {ABC}
+}
+
+@misc{,
+  date = {1974-01-02},
+  month = mar,
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {248},
+  number = {5443},
+  pages = {30--31},
+  author = {DEF},
+  title = {no key supplied 3},
+  journaltitle = {ABC}
+}

--- a/tests/testthat/test-drop_name.R
+++ b/tests/testthat/test-drop_name.R
@@ -173,7 +173,7 @@ test_that("bulk operations work properly", {
         "Title1", c("Alice2", "Bob2", "Charlie2"), "JoURP1", "Alice2021", "2021", "someDOI3",
       )
 
-      expect_warning(drop_name(bib = bulk_data_dup, cite_key = "Alice2021", output_dir = "drop_name05"), "BIBTEX keys are not unique")
+      expect_warning(drop_name(bib = bulk_data_dup, cite_key = "Alice2021", output_dir = "drop_name05"), "There are duplicated bibtex keys")
     }
   )
 


### PR DESCRIPTION
Moves deduplication from `drop_name_crossref()` to `drop_name()`.
Furthermore generic keys are added when keys are not given in the *.bib file.