### PR TITLE
Add the ability to turn a QR code into a hyperlink

### DIFF
--- a/R/drop_name.R
+++ b/R/drop_name.R
@@ -34,6 +34,7 @@
 #' BibTeX strings, but not needed for the rendering. TRUE by default, but can be set to FALSE, if the {} are needed.
 #' @param qr_size Specifies the height/width of the rendered QR code in px. Default: 250px, minimum: 150px. Ignored for SVG output.
 #' @param qr_color Specifies the foreground color of the QR code as hex-string, e.g. "#00FF00"; default is black: "#000000".
+#' @param qr_hyperlink Logical. Should the QR code be a hyperlink?
 #' @param vc_width Specifies the width of the text part of the visual citation in px.
 #' This can be adjusted to accommodate e.g. untypically long or short titles. Default: 600px
 #' @param ... Allows for custom style arguments to override predefined styles. Supported are: author_size, author_font,
@@ -92,6 +93,7 @@ drop_name <- function(bib, cite_key,
                       include_qr = "link",
                       qr_size = 250,
                       qr_color = "#000000",
+                      qr_hyperlink = FALSE,
                       vc_width = 600,
                       style = "modern",
                       path_absolute = FALSE,
@@ -128,6 +130,7 @@ drop_name <- function(bib, cite_key,
   # style content is not further checked, as unknown styles will be handled as "none" in get_css_styles()
   stopifnot(is.logical(path_absolute))
   stopifnot(is.logical(use_xaringan))
+  stopifnot(is.logical(qr_hyperlink))
   stopifnot(is.logical(clean_strings))
 
   # READ AND CHECK BIB FILE or BIBENTRY
@@ -353,6 +356,7 @@ drop_name <- function(bib, cite_key,
     use_xaringan = ifelse(export_as == "png", FALSE, use_xaringan),
     qr_size = qr_size,
     qr_color = qr_color,
+    qr_hyperlink = qr_hyperlink,
     vc_width = vc_width,
     style_args = style_args
   )

--- a/man/drop_html.Rd
+++ b/man/drop_html.Rd
@@ -9,6 +9,7 @@ drop_html(
   include_qr,
   qr_size = 250,
   qr_color = "#000000",
+  qr_hyperlink = FALSE,
   vc_width = 600,
   output_dir,
   style,
@@ -29,6 +30,8 @@ data for one reference to create the visual citation.}
 \item{qr_size}{Specifies the height/width of the rendered QR code in px. Default: 250px, minimum: 150px. Ignored for SVG output.}
 
 \item{qr_color}{Specifies the foreground color of the QR code as hex-string, e.g. "#00FF00".}
+
+\item{qr_hyperlink}{Logical. Should the QR code be a hyperlink?}
 
 \item{vc_width}{Specifies the width of the text part of the visual citation in px.
 This can be adjusted to accommodate e.g. untypically long or short titles. Default: 600px}

--- a/man/drop_name.Rd
+++ b/man/drop_name.Rd
@@ -13,6 +13,7 @@ drop_name(
   include_qr = "link",
   qr_size = 250,
   qr_color = "#000000",
+  qr_hyperlink = FALSE,
   vc_width = 600,
   style = "modern",
   path_absolute = FALSE,
@@ -49,6 +50,8 @@ For webshot you need to install phantomJS once (see 'webshot' documentation).}
 \item{qr_size}{Specifies the height/width of the rendered QR code in px. Default: 250px, minimum: 150px. Ignored for SVG output.}
 
 \item{qr_color}{Specifies the foreground color of the QR code as hex-string, e.g. "#00FF00"; default is black: "#000000".}
+
+\item{qr_hyperlink}{Logical. Should the QR code be a hyperlink?}
 
 \item{vc_width}{Specifies the width of the text part of the visual citation in px.
 This can be adjusted to accommodate e.g. untypically long or short titles. Default: 600px}

--- a/man/drop_name_crossref.Rd
+++ b/man/drop_name_crossref.Rd
@@ -37,6 +37,7 @@ relative to the rendered presentation, not relative to the visual citation.}
 BibTeX strings, but not needed for the rendering. TRUE by default, but can be set to FALSE, if the {} are needed.}
     \item{\code{qr_size}}{Specifies the height/width of the rendered QR code in px. Default: 250px, minimum: 150px. Ignored for SVG output.}
     \item{\code{qr_color}}{Specifies the foreground color of the QR code as hex-string, e.g. "#00FF00"; default is black: "#000000".}
+    \item{\code{qr_hyperlink}}{Logical. Should the QR code be a hyperlink?}
     \item{\code{vc_width}}{Specifies the width of the text part of the visual citation in px.
 This can be adjusted to accommodate e.g. untypically long or short titles. Default: 600px}
   }}

--- a/man/namedropR-package.Rd
+++ b/man/namedropR-package.Rd
@@ -6,7 +6,7 @@
 \alias{namedropR-package}
 \title{namedropR: Create Visual Citations for Presentation Slides}
 \description{
-\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
 Provides 'visual citations' containing the metadata of a scientific paper and a 'QR' code. A 'visual citation' is a banner containing title, authors, journal and year of a publication. This package can create such banners based on 'BibTeX' and 'BibLaTeX' references and includes a QR code pointing to the 'DOI'. The resulting HTML object or PNG image can be included in a presentation to point the audience to good resources for further reading. Styling is possible via predefined designs or via custom 'CSS'. This package is not intended as replacement for proper reference manager packages, but a tool to enrich scientific presentation slides.
 }


### PR DESCRIPTION
Closes #50 

I basically only made changes in `drop_html()`. I pulled out the code for making the QR image into its own function, `make_qr_img()`, so that it was easier to add some conditional logic for whether to wrap it in an `<a>` tag as a hyperlink based on the new argument `qr_hyperlink`. I set `qr_hyperlink` to `FALSE` by default to be consistent with previous behaviour.

Let me know if you would like any changes!